### PR TITLE
Fixed advanced watermill ghost causing error spam when out of bounds past northern/southern map edge

### DIFF
--- a/1.4/Source/VanillaPowerExpanded/VanillaPowerExpanded/Watermill/PlaceWorker_AdvancedWatermill.cs
+++ b/1.4/Source/VanillaPowerExpanded/VanillaPowerExpanded/Watermill/PlaceWorker_AdvancedWatermill.cs
@@ -29,7 +29,7 @@ namespace VanillaPowerExpanded
         {
             foreach (IntVec3 c in CompPowerPlantWater.WaterCells(loc, rot))
             {
-                if (!map.terrainGrid.TerrainAt(c).affordances.Contains(TerrainAffordanceDefOf.MovingFluid))
+                if (!c.InBounds(map) || !map.terrainGrid.TerrainAt(c).affordances.Contains(TerrainAffordanceDefOf.MovingFluid))
                 {
                     return false;
                 }


### PR DESCRIPTION
This is the same bug that happens with Vanilla RW watermill generators. The error spam happens when the area that needs to be over water is out of bounds past northern/southern map border.

The call to `TerrainAt` would convert the cell to (int) index. In case of areas past northern/southern map edges, it would result in index out of bounds of terrain grid array. In case of areas out bound of eastern/western map edge, it would try reading data from areas somewhere else on the map (as the values would end withing bounds).

A simple check if the cell is within bounds is going to fix this issue.